### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 YaST UI rest api framework for integration testing.
 Project started by @lslezak, with support of @cwh42 and @OleksandrOrlov.
 
-Solution allows to query UI properties over http using API. This allows to
-automate UI interaction steps and avoid screen-based tools.
+The solution allows to query the UI properties over HTTP using a REST API.
+This allows to automate UI interaction steps and avoid screen-based tools.
 API allows reading properties of the UI, so entered text can be validated.
 
 To start application with rest API enabled, use following commands:
@@ -14,88 +14,94 @@ To start application with rest API enabled, use following commands:
 After that, you can get documentation how to interact with UI by accessing
 `http://localhost:9999`.
 
-By setting `YUITest_HTTP_REMOTE=1` environmental variable, one can allow connections
-from the remote host.
+### Remote Access
+
+By setting `YUI_HTTP_REMOTE=1` environmental variable, one can allow connections
+from remote hosts.
+
+:warning: Security warning: Enable the remote access only in trusted environment,
+do not use it for production systems!
 
 
-<body>
-        <h1>LibYUI Embedded Webserver</h1>
-        <p>This webserver provides a REST API for the LibYUI application.</p>
-        <p>It can be used for testing and controlling the application in automated tests.</p>
-        <br>
-        <h2>Short Documentation</h2>
-        <h3>Application</h3>
-        <p>Request: GET <a href='/application'>/application</a>
-        </p>
-        <h4>Description</h4>
-        <p>Get the application and UI generic properties like text or graphical mode, dialog size, screen size and supported UI featues.</p>
-        <h4>Response</h4>
-        <p>JSON format</p>
-        <h4>Examples</h4>
-        <p>
-                <pre>  curl http://localhost:9999/application</pre>
-        </p>
-        <hr>
-        <h3>Dump Whole Dialog</h3>
-        <p>Request: GET <a href='/dialog'>/dialog</a>
-        </p>
-        <h4>Description</h4>
-        <p>Get the complete dialog structure in the JSON format. The result contains a nested structure exactly following the structure of the current dialog.</p>
-        <h4>Response</h4>
-        <p>JSON format</p>
-        <h4>Examples</h4>
-        <p>
-                <pre>  curl http://localhost:9999/dialog</pre>
-        </p>
-        <hr>
-        <h3>Read Specific Widgets</h3>
-        <p>Request: GET <a href='/widgets'>/widgets</a>
-        </p>
-        <h4>Description</h4>
-        <p>Return only the selected widgets (in JSON format). The result is a flat list (no nested structures).</p>
-        <h4>Parameters</h4>
-        <p>Filter widgets: <ul>
-                        <li>
-                                <b>id</b> - widget ID serialized as string, might include special characters like backtick (\`)</li>
-                        <li>
-                                <b>label</b> - widget label as currently displayed (i.e. translated!) </li>
-                        <li>
-                                <b>type</b> - widget type</li>
-                </ul>
-        </p>
-        <h4>Response</h4>
-        <p>JSON format</p>
-        <h4>Examples</h4>
-        <p>
-                <pre>  curl 'http://localhost:9999/widgets?id=next'</pre>
-                <pre>  curl 'http://localhost:9999/widgets?label=Next'</pre>
-                <pre>  curl 'http://localhost:9999/widgets?type=YCheckBox'</pre>
-        </p>
-        <hr>
-        <h3>Change Widgets, Do an Action</h3>
-        <p>Request: POST /widgets</p>
-        <h4>Description</h4>
-        <p>Do an action with specified widgets.</p>
-        <h4>Parameters</h4>
-        <p>Filter the widgets, one of: <ul>
-                        <li>
-                                <b>id</b> - widget ID serialized as string, might include special characters like backtick (\`)</li>
-                        <li>
-                                <b>label</b> - widget label as currently displayed (i.e. translated!) </li>
-                        <li>
-                                <b>type</b> - widget type</li>
-                </ul> Then specify the action: <ul>
-                        <li>
-                                <b>action</b> - action to do</li>
-                        <li>
-                                <b>value</b> (optional) - new value or a parameter of the action</li>
-                </ul>
-        </p>
-        <h4>Response</h4>
-        <p>JSON format</p>
-        <h4>Examples</h4>
-        <p>
-                <pre> press the "next" button  curl -X POST 'http://localhost:9999/widgets?id=next&action=press'</pre>
-                <pre> set value "test" for the InputField with label "Description"  curl -X POST 'http://localhost:9999/widgets?label=Description&action=enter&value=test'</pre>
-        </p>
-</body>
+---
+<h1>LibYUI Embedded Webserver</h1>
+<p>This webserver provides a REST API for the LibYUI application.</p>
+<p>It can be used for testing and controlling the application in automated tests.</p>
+<br>
+<h2>Short Documentation</h2>
+<h3>Application</h3>
+<p>Request: GET <a href='/application'>/application</a>
+</p>
+<h4>Description</h4>
+<p>Get the application and UI generic properties like text or graphical mode, dialog size, screen size and supported UI featues.</p>
+<h4>Response</h4>
+<p>JSON format</p>
+<h4>Examples</h4>
+<p>
+        <pre>curl http://localhost:9999/application</pre>
+</p>
+<hr>
+<h3>Dump Whole Dialog</h3>
+<p>Request: GET <a href='/dialog'>/dialog</a>
+</p>
+<h4>Description</h4>
+<p>Get the complete dialog structure in the JSON format. The result contains a nested structure exactly following the structure of the current dialog.</p>
+<h4>Response</h4>
+<p>JSON format</p>
+<h4>Examples</h4>
+<p>
+        <pre>curl http://localhost:9999/dialog</pre>
+</p>
+<hr>
+<h3>Read Specific Widgets</h3>
+<p>Request: GET <a href='/widgets'>/widgets</a>
+</p>
+<h4>Description</h4>
+<p>Return only the selected widgets (in JSON format). The result is a flat list (no nested structures).</p>
+<h4>Parameters</h4>
+<p>Filter widgets: <ul>
+                <li>
+                        <b>id</b> - widget ID serialized as string, might include special characters like backtick (\`)</li>
+                <li>
+                        <b>label</b> - widget label as currently displayed (i.e. translated!) </li>
+                <li>
+                        <b>type</b> - widget type</li>
+        </ul>
+</p>
+<h4>Response</h4>
+<p>JSON format</p>
+<h4>Examples</h4>
+<p>
+        <pre>curl 'http://localhost:9999/widgets?id=next'</pre>
+        <pre>curl 'http://localhost:9999/widgets?label=Next'</pre>
+        <pre>curl 'http://localhost:9999/widgets?type=YCheckBox'</pre>
+</p>
+<hr>
+<h3>Change Widgets, Do an Action</h3>
+<p>Request: POST /widgets</p>
+<h4>Description</h4>
+<p>Do an action with specified widgets.</p>
+<h4>Parameters</h4>
+<p>Filter the widgets, one of: <ul>
+                <li>
+                        <b>id</b> - widget ID serialized as string, might include special characters like backtick (\`)</li>
+                <li>
+                        <b>label</b> - widget label as currently displayed (i.e. translated!) </li>
+                <li>
+                        <b>type</b> - widget type</li>
+        </ul> Then specify the action: <ul>
+                <li>
+                        <b>action</b> - action to do</li>
+                <li>
+                        <b>value</b> (optional) - new value or a parameter of the action</li>
+        </ul>
+</p>
+<h4>Response</h4>
+<p>JSON format</p>
+<h4>Examples</h4>
+<p>
+        Press the "next" button:
+        <pre>curl -X POST 'http://localhost:9999/widgets?id=next&action=press'</pre>
+        Set value "test" for the InputField with label "Description":
+        <pre>curl -X POST 'http://localhost:9999/widgets?label=Description&action=enter&value=test'</pre>
+</p>

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,21 @@
+# TODO
+
+## Important
+
+- [ ] Split the package into separate Ncurses and Qt parts
+(less dependencies, not possible to test a minimal system without X)
+- [ ] Support for more widgets and attributes
+
+## Security
+
+- [ ] User authentication via basic auth([tutorial](
+https://www.gnu.org/software/libmicrohttpd/tutorial.html#Supporting-basic-authentication),
+[documentation](https://www.gnu.org/software/libmicrohttpd/manual/html_node/microhttpd_002ddauth-basic.html#microhttpd_002ddauth-basic),
+[example](https://github.com/Metaswitch/libmicrohttpd/blob/master/src/examples/authorization_example.c))
+- [ ] SSL for encryption and peer verification ([tutorial](https://www.gnu.org/software/libmicrohttpd/tutorial.html#Adding-a-layer-of-security))
+
+
+## Optional
+
+- [ ] Support also the Gtk UI
+- [ ] IPv6 support ([example](https://github.com/rboulton/libmicrohttpd/blob/master/src/examples/dual_stack_example.c))

--- a/package/libyui-rest-api.spec
+++ b/package/libyui-rest-api.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package libyui-rest-api
 #
-# Copyright (c) 2018-2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -43,18 +43,18 @@ BuildRequires:  libmicrohttpd-devel
 BuildRequires:  pkg-config
 
 # ncurses UI specific
-BuildRequires:  ncurses-devel
 BuildRequires:  libyui-ncurses-devel
+BuildRequires:  ncurses-devel
 
 # Qt UI specific
-BuildRequires:  libyui-qt-devel
 BuildRequires:  fontconfig-devel
+BuildRequires:  libyui-qt-devel
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Gui)
+BuildRequires:  pkgconfig(Qt5Svg)
+BuildRequires:  pkgconfig(Qt5Svg)
 BuildRequires:  pkgconfig(Qt5Widgets)
-BuildRequires:  pkgconfig(Qt5Svg)
 BuildRequires:  pkgconfig(Qt5X11Extras)
-BuildRequires:  pkgconfig(Qt5Svg)
 
 %if %{with coverage}
 # normally the coverage feature should not be used out of CI
@@ -62,19 +62,16 @@ BuildRequires:  pkgconfig(Qt5Svg)
 BuildRequires:  lcov
 %endif
 
-Url:            http://github.com/libyui/
-Summary:        GUI-abstraction library
+Url:            http://github.com/libyui/libyui-rest-api
+Summary:        Libyui - REST API plugin
 License:        LGPL-2.1-only OR LGPL-3.0-only
 Group:          System/Libraries
 
 %description
-This is the user interface engine that provides the abstraction from
-graphical user interfaces (Qt, Gtk) and text based user interfaces
-(ncurses).
+This package provides a libyui REST API plugin.
 
-Originally developed for YaST, it can now be used independently of
-YaST for generic (C++) applications. This package has very few
-dependencies.
+It allows inspecting and controlling the UI remotely via
+an HTTP REST API, it is designed for automated tests.
 
 %package -n %{bin_name}
 
@@ -84,18 +81,15 @@ Obsoletes:      yast2-rest-api < 0.1.0
 Requires:       libyui%{so_version}
 Requires:       yui_backend = %{so_version}
 
-Url:            http://github.com/libyui/
-Summary:        Libyui - GUI-abstraction library
+Url:            http://github.com/libyui/libyui-rest-api
+Summary:        Libyui - REST API plugin
 Group:          System/Libraries
 
 %description -n %{bin_name}
-This is the user interface engine that provides the abstraction from
-graphical user interfaces (Qt, Gtk) and text based user interfaces
-(ncurses).
+This package provides a libyui REST API plugin.
 
-Originally developed for YaST, it can now be used independently of
-YaST for generic (C++) applications. This package has very few
-dependencies.
+It allows inspecting and controlling the UI remotely via
+an HTTP REST API, it is designed for automated tests.
 
 %package devel
 
@@ -114,16 +108,9 @@ Summary:        Libyui header files
 Group:          Development/Languages/C and C++
 
 %description devel
-This is the user interface engine that provides the abstraction from
-graphical user interfaces (Qt, Gtk) and text based user interfaces
-(ncurses).
+This package provides a libyui REST API plugin.
 
-Originally developed for YaST, it can now be used independently of
-YaST for generic (C++) applications. This package has very few
-dependencies.
-
-This can be used independently of YaST for generic (C++) applications.
-This package has very few dependencies.
+This is a development subpackage.
 
 %prep
 %setup -q -n %{name}-%{version}

--- a/src/NCHttpDialog.cc
+++ b/src/NCHttpDialog.cc
@@ -13,7 +13,7 @@
   Floor, Boston, MA 02110-1301 USA
 */
 
-#define	 YUILogComponent "ncurses"
+#define	 YUILogComponent "rest-api"
 #include <yui/YUILog.h>
 #include "NCHttpDialog.h"
 
@@ -27,7 +27,7 @@
 #include "YHttpServer.h"
 #include <yui/YDialogSpy.h>
 #include <yui/YDialog.h>
- #include <chrono>
+#include <chrono>
 
 #include "ncursesw.h"
 
@@ -86,9 +86,9 @@ static int wait_for_input(int timeout_millisec)
             if (fd_max < fd) fd_max = fd;
         }
 
-        yuiWarning() << "Calling select()... " << std::endl;
+        yuiDebug() << "Calling select()... " << std::endl;
         int retval = select( fd_max + 1, &fdset_read, &fdset_write, &fdset_excpt, tv_ptr );
-        yuiWarning() << "select() result: " << retval << std::endl;
+        yuiDebug() << "select() result: " << retval << std::endl;
 
         if ( retval < 0 )
         {
@@ -118,7 +118,7 @@ static int wait_for_input(int timeout_millisec)
                     server_ready = true;
             }
 
-            yuiWarning() << "Server ready: " << server_ready << std::endl;
+            yuiDebug() << "Server ready: " << server_ready << std::endl;
 
             if (server_ready)
             {
@@ -129,9 +129,9 @@ static int wait_for_input(int timeout_millisec)
                     std::chrono::steady_clock::time_point finish = std::chrono::steady_clock::now();
 
                     int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(finish - start).count();
-                    yuiWarning() << "Elapsed time (ms): " << elapsed << std::endl;
+                    yuiDebug() << "Elapsed time (ms): " << elapsed << std::endl;
                     timeout_millisec -= elapsed;
-                    yuiWarning() << "Remaining time out (ms): " << timeout_millisec << std::endl;
+                    yuiDebug() << "Remaining time out (ms): " << timeout_millisec << std::endl;
 
                     // spent too much time
                     if (timeout_millisec <= 0)
@@ -147,7 +147,7 @@ static int wait_for_input(int timeout_millisec)
                 int	ch = ::getch();
                 if (ch != ERR)
                 {
-                    yuiWarning() << "Input available" << std::endl;
+                    yuiMilestone() << "New input available" << std::endl;
                     // put it back and finish
                     ::ungetch(ch);
                     return 0;
@@ -157,13 +157,13 @@ static int wait_for_input(int timeout_millisec)
         // no input within timeout
         else
         {
-            yuiWarning() << "Timeout " << timeout_millisec << "ms reached" << std::endl;
+            yuiDebug() << "Timeout " << timeout_millisec << "ms reached" << std::endl;
             return timeout_millisec_orig;
         }
     }
     while ( !FD_ISSET( 0, &fdset_read ) );
 
-    // if there is an user input we do not need the spent time
+    // if there is an user input we do not need to spent the time
     return 0;
 }
 
@@ -172,7 +172,7 @@ wint_t NCHttpDialog::getch( int timeout_millisec )
 {
     wint_t got = WEOF;
 
-    yuiWarning() << "NCHttpDialog::getch timeout: " << timeout_millisec << std::endl;
+    yuiDebug() << "NCHttpDialog::getch timeout: " << timeout_millisec << std::endl;
 
     if ( timeout_millisec < 0 )
     {
@@ -186,9 +186,9 @@ wint_t NCHttpDialog::getch( int timeout_millisec )
         {
             // wait for input
             int slept = wait_for_input(timeout_millisec);
-            yuiWarning() << "slept: " << slept << std::endl;
+            yuiDebug() << "slept: " << slept << std::endl;
             timeout_millisec -= slept;
-            yuiWarning() << "new timeout: " << timeout_millisec << std::endl;
+            yuiDebug() << "new timeout: " << timeout_millisec << std::endl;
 
             got = getinput();
         }
@@ -210,7 +210,7 @@ wint_t NCHttpDialog::getch( int timeout_millisec )
 
 	do
 	{
-	    got =  NCHttpDialog::getch( timeout_millisec );
+	    got = NCHttpDialog::getch( timeout_millisec );
 	}
 	while ( timeout_millisec < 0 && got == WEOF && --i );
     }

--- a/src/NCHttpWidgetFactory.cc
+++ b/src/NCHttpWidgetFactory.cc
@@ -16,7 +16,7 @@
 #include "NCHttpWidgetFactory.h"
 #include <yui/YUIException.h>
 
-#define  YUILogComponent "ncurses"
+#define  YUILogComponent "rest-api"
 #include <yui/YUILog.h>
 #include "YNCHttpUI.h"
 #include "NCHttpDialog.h"

--- a/src/YHttpAppHandler.cc
+++ b/src/YHttpAppHandler.cc
@@ -57,7 +57,7 @@ void YHttpAppHandler::body(struct MHD_Connection* connection,
         Json::Value relnotes_json;
         
         for(const auto &pair: relnotes) {
-            info[pair.first] = pair.second;
+            relnotes_json[pair.first] = pair.second;
         }
         
         info["release_notes"] = relnotes_json;

--- a/src/YHttpServer.cc
+++ b/src/YHttpServer.cc
@@ -26,7 +26,7 @@
 
 #include <microhttpd.h>
 
-#define YUILogComponent "http-ui"
+#define YUILogComponent "rest-api"
 #include "YUILog.h"
 #include "YDialog.h"
 #include "YJsonSerializer.h"
@@ -95,18 +95,9 @@ YHttpServerSockets YHttpServer::sockets()
     }
 
     for(int i = 0; i <= max; ++i) {
-        if (FD_ISSET(i, &rs)) {
-            yuiMilestone() << "Reading FD: " << i << std::endl;
-            ret.add_read(i);
-        }
-        if (FD_ISSET(i, &ws)) {
-            yuiMilestone() << "Writing FD: " << i << std::endl;
-            ret.add_write(i);
-        }
-        if (FD_ISSET(i, &es)) {
-            yuiMilestone() << "Exception FD: " << i << std::endl;
-            ret.add_exception(i);
-        }
+        if (FD_ISSET(i, &rs)) ret.add_read(i);
+        if (FD_ISSET(i, &ws)) ret.add_write(i);
+        if (FD_ISSET(i, &es)) ret.add_exception(i);
     }
 
     if (ret.empty())
@@ -119,7 +110,7 @@ int YHttpServer::handle(struct MHD_Connection* connection,
     const char* url, const char* method, const char* upload_data,
     size_t* upload_data_size)
 {
-    yuiMilestone() << "Processing " << method << " request: "<< url << ", data size: " << *upload_data_size << std::endl;
+    yuiMilestone() << "Processing " << method << " request: "<< url << ", input data size: " << *upload_data_size << std::endl;
 
     // find the handler
     for(YHttpMount m: _mounts)
@@ -142,7 +133,6 @@ requestHandler(void *srv,
           const char *version,
           const char *upload_data, size_t *upload_data_size, void **ptr)
 {
-    yuiMilestone() << "Received connection from " << std::endl;
     // remember the callback status
     static int aptr;
 
@@ -161,7 +151,6 @@ requestHandler(void *srv,
 }
 
 static int onConnect(void *srv, const struct sockaddr *addr, socklen_t addrlen) {
-        yuiMilestone() << "Received connection from " << std::endl;
     if (addr->sa_family == AF_INET) {
         struct sockaddr_in *addr_in = (struct sockaddr_in *) addr;
         // macro INET_ADDRSTRLEN contains the maximum length of an IPv4 address

--- a/src/YHttpWidgetsActionHandler.h
+++ b/src/YHttpWidgetsActionHandler.h
@@ -25,7 +25,7 @@
 #include <functional>
 #include <microhttpd.h>
 
-#define YUILogComponent "http-ui"
+#define YUILogComponent "rest-api"
 #include "YUILog.h"
 
 class YHttpWidgetsActionHandler : public YHttpHandler

--- a/src/YNCHttpUI.cc
+++ b/src/YNCHttpUI.cc
@@ -92,7 +92,7 @@ void YNCHttpUI::idleLoop( int fd_ycp )
         int fd_max = fd_ycp;
 
          // watch HTTP server fd
-         yuiMilestone() << "Adding HTTP server notifiers..." << std::endl;
+         yuiDebug() << "Adding HTTP server notifiers..." << std::endl;
          YHttpServerSockets sockets = YHttpServer::yserver()->sockets();
 
          for(int fd: sockets.read())
@@ -113,9 +113,9 @@ void YNCHttpUI::idleLoop( int fd_ycp )
              if (fd_max < fd) fd_max = fd;
          }
 
-         yuiWarning() << "Calling select()... " << std::endl;
- 	 retval = select( fd_max + 1, &fdset_read, &fdset_write, &fdset_excpt, &tv );
-         yuiWarning() << "select() result: " << retval << std::endl;
+         yuiDebug() << "Calling select()... " << std::endl;
+         retval = select( fd_max + 1, &fdset_read, &fdset_write, &fdset_excpt, &tv );
+         yuiDebug() << "select() result: " << retval << std::endl;
 
          if ( retval < 0 )
          {
@@ -145,7 +145,7 @@ void YNCHttpUI::idleLoop( int fd_ycp )
                      server_ready = true;
              }
 
-             yuiWarning() << "Server ready: " << server_ready << std::endl;
+             yuiMilestone() << "Server ready: " << server_ready << std::endl;
 
              if (server_ready)
                  YHttpServer::yserver()->process_data();
@@ -160,7 +160,7 @@ void YNCHttpUI::idleLoop( int fd_ycp )
 
  		if ( ncd )
  		{
-                    yuiMilestone() << "Casted to NCHttpDialog" << std::endl;
+                    yuiDebug() << "Casted to NCHttpDialog" << std::endl;
  		    extern NCBusyIndicator* NCBusyIndicatorObject;
 
  		    if ( NCBusyIndicatorObject )

--- a/src/YQHttpUI.cc
+++ b/src/YQHttpUI.cc
@@ -170,6 +170,7 @@ YQHttpUI::~YQHttpUI()
     }
 
     delete _signalReceiver;
+    _signalReceiver = nullptr;
 }
 
 extern YUI * createYQHttpUI( bool withThreads )


### PR DESCRIPTION
- Updated documentation, added `TODO`
- Reformatted the .spec file, fixed the description
- Fixed segfault at exit in Qt UI (double `free`)
- Decreased logging (it was mainly important during development, now we can use the debug level to make it less verbose or even remove some useless messages)
- Always use the `rest-api` logger component (to distinguish it from the standard qt or ncurses plugins)